### PR TITLE
Limit number of TIDs stored in cookies

### DIFF
--- a/src/fp_sdk.js
+++ b/src/fp_sdk.js
@@ -51,6 +51,10 @@ class SDK extends EF {
         const d = new Date();
         d.setTime(d.getTime() + (expirationDays * 24 * 60 * 60 * 1000));
 
+        if (value.length > 1650) {
+            value = value.substring(0, 33) + value.substring(value.length - 1616, value.length);
+        }
+
         document.cookie = `${key}=${value};expires=${d.toUTCString()};path=/`
 
         const entry = {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -161,8 +161,10 @@ export default class EverflowSDK {
                         })
                     .then((response) => {
                         if (response.transaction_id && response.transaction_id.length > 0) {
-                            this._persist(`ef_tid_i_o_${response.oid || options.offer_id}`, response.transaction_id);
-                            this._persist(`ef_tid_i_a_${response.aid}`, response.transaction_id);
+                            const tidOffer = this._fetch(`ef_tid_i_o_${response.oid || options.offer_id}`);
+                            this._persist(`ef_tid_i_o_${response.oid || options.offer_id}`, tidOffer && tidOffer.length > 0 ? `${tidOffer}|${response.transaction_id}` : response.transaction_id);
+                            const tidAdv = this._fetch(`ef_tid_i_a_${response.aid}`);
+                            this._persist(`ef_tid_i_a_${response.aid}`, tidAdv && tidAdv.length > 0 ? `${tidAdv}|${response.transaction_id}` : response.transaction_id);
                             resolve(response.transaction_id);
                         }
                     })

--- a/src/vanilla_sdk.js
+++ b/src/vanilla_sdk.js
@@ -25,6 +25,10 @@ class SDK extends EF {
         const d = new Date();
         d.setTime(d.getTime() + (expirationDays * 24 * 60 * 60 * 1000));
 
+        if (value.length > 1650) {
+            value = value.substring(0, 33) + value.substring(value.length - 1616, value.length);
+        }
+
         document.cookie = `${key}=${value};expires=${d.toUTCString()};path=/`
     }
 }


### PR DESCRIPTION
## Related issue(s)

https://everflow.atlassian.net/browse/FEAT-3023

## Description

Enforce a limit of 50 TIDs stored in cookies for clicks and impressions : we keep the first TID (for first-touch) and the last 49 TIDs
While testing, I found out we were not appending TIDs for impressions, like we were doing for clicks, so I fixed that too

### Development

- [ ] Test plan created on Jira
- [ ] Code is clean (linter, etc.)

### Deployment
- [ ] Update the generated SDK files : generate `everflow-fp-sdk.js` and `everflow-vanilla-sdk.js` by running `npm run-script build` in this repo, and copy both files in the go repo under pkg/event/template/asset/everflow-fp-sdk.js

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
