### PR TITLE
Add support for the new `alt_tid` attribution feature

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -190,6 +190,12 @@ export default class EverflowSDK {
           this._setDefaultFromURL(queryParams, "ScCid");
         }
 
+        if (this._isDefined(options.alt_tid)) {
+          queryParams.set("alt_tid", options.alt_tid);
+        } else {
+          this._setDefaultFromURL(queryParams, "alt_tid");
+        }
+
         if (this._isDefined(options.coupon_code)) {
           queryParams.set("__cc", options.coupon_code || "");
         }
@@ -275,6 +281,8 @@ export default class EverflowSDK {
     if (this.urlParameter("TCLID")) {
       sub1 = "Taboola";
     }
+
+    // No support for alt_tid on organic clicks
 
     return {
       sub1: this.urlParameter("sub1") || sub1,
@@ -410,6 +418,12 @@ export default class EverflowSDK {
           queryParams.set("sccid", options.sccid);
         } else {
           this._setDefaultFromURL(queryParams, "ScCid");
+        }
+
+        if (this._isDefined(options.alt_tid)) {
+          queryParams.set("alt_tid", options.alt_tid);
+        } else {
+          this._setDefaultFromURL(queryParams, "alt_tid");
         }
 
         if (options.disable_fingerprinting === true) {


### PR DESCRIPTION
This PR adds support for the `alt_tid` parameter on the SDK.

It works exactly the way `fbclid` and `gclid` do as far as attribution is concerned.

Note that we do not support `alt_tid` on organic clicks (since it doesn't map to a system by default it wouldn't make sense).